### PR TITLE
Added debug printout of current timestamp in PACMANFrameProcessor

### DIFF
--- a/include/ndreadoutlibs/pacman/PACMANFrameProcessor.hpp
+++ b/include/ndreadoutlibs/pacman/PACMANFrameProcessor.hpp
@@ -22,6 +22,7 @@
 #include <string>
 
 using dunedaq::readoutlibs::logging::TLVL_BOOKKEEPING;
+using dunedaq::readoutlibs::logging::TLVL_FRAME_RECEIVED;
 
 namespace dunedaq {
 namespace ndreadoutlibs {

--- a/include/ndreadoutlibs/pacman/detail/PACMANFrameProcessor.hxx
+++ b/include/ndreadoutlibs/pacman/detail/PACMANFrameProcessor.hxx
@@ -25,6 +25,9 @@ PACMANFrameProcessor::timestamp_check(frameptr fp)
 
   // Acquire timestamp
   m_current_ts = fp->get_timestamp();
+  uint64_t clock_frequency = 50000000;  // change this sometime!
+  double data_time = static_cast<double>(m_current_ts % (clock_frequency*1000)) / static_cast<double>(clock_frequency);  // NOLINT
+  TLOG_DEBUG(TLVL_FRAME_RECEIVED) << "Received PACMAN frame timestamp value of " << m_current_ts << " ticks (..." << std::fixed << std::setprecision(8) << data_time << " sec)";
 
   // Check timestamp
   // RS warning : not fixed rate!


### PR DESCRIPTION
This change is part of a set of changes that I have been working on that will hopefully help us understand what is going wrong when DataRequests result in empty Fragments when running with emulated/playback data.

This particular change does not depend on changes in any other repos, so it can be tested and merged independently of other changes.

To enable the new debug message, one would use `tonM -n DataLinkHandler DEBUG+19` after enabling TRACE messages, for example, by specifying a trace file using the TRACE FILE env var.