### PR TITLE
FD/ND split of detdataformats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(opmonlib REQUIRED)
 find_package(readoutlibs REQUIRED)
 find_package(daqdataformats REQUIRED)
 find_package(detdataformats REQUIRED)
+find_package(nddetdataformats REQUIRED)
 find_package(folly REQUIRED)
 find_package(Boost COMPONENTS iostreams REQUIRED)
 set(BOOST_LIBS Boost::iostreams ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_LIBRARIES})
@@ -32,6 +33,7 @@ set(NDREADOUTLIBS_DEPENDENCIES
   opmonlib::opmonlib
   daqdataformats::daqdataformats
   detdataformats::detdataformats
+  nddetdataformats::nddetdataformats
 )
 
 ##############################################################################

--- a/cmake/ndreadoutlibsConfig.cmake.in
+++ b/cmake/ndreadoutlibsConfig.cmake.in
@@ -10,6 +10,7 @@ find_dependency(appfwk)
 find_dependency(readoutlibs)
 find_dependency(daqdataformats)
 find_dependency(detdataformats)
+find_dependency(nddetdataformats)
 find_dependency(folly)
 find_dependency(Boost COMPONENTS iostreams)
 

--- a/include/ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp
+++ b/include/ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp
@@ -11,7 +11,7 @@
 #include "iomanager/IOManager.hpp"
 #include "daqdataformats/FragmentHeader.hpp"
 #include "daqdataformats/SourceID.hpp"
-#include "detdataformats/mpd/MPDFrame.hpp"
+#include "nddetdataformats/MPDFrame.hpp"
 #include "logging/Logging.hpp"
 #include <cstdint> // uint_t types
 #include <memory>  // unique_ptr

--- a/include/ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp
+++ b/include/ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp
@@ -37,8 +37,8 @@ namespace dunedaq {
 
 	bool operator<(const MPD_MESSAGE_STRUCT& other) const
 	{
-	  auto thisptr = reinterpret_cast<const dunedaq::detdataformats::mpd::MPDFrame*>(&data[0]);        // NOLINT
-	  auto otherptr = reinterpret_cast<const dunedaq::detdataformats::mpd::MPDFrame*>(&other.data[0]); // NOLINT
+	  auto thisptr = reinterpret_cast<const dunedaq::nddetdataformats::MPDFrame*>(&data[0]);        // NOLINT
+	  auto otherptr = reinterpret_cast<const dunedaq::nddetdataformats::MPDFrame*>(&other.data[0]); // NOLINT
 	  return (thisptr->get_timestamp() < otherptr->get_timestamp()) // NOLINT
 		      ? true
 		      : false;
@@ -46,7 +46,7 @@ namespace dunedaq {
 	
 	uint64_t get_timestamp() const // NOLINT(build/unsigned)
 	{
-	  auto thisptr = reinterpret_cast<const dunedaq::detdataformats::mpd::MPDFrame*>(&data[0]);        // NOLINT
+	  auto thisptr = reinterpret_cast<const dunedaq::nddetdataformats::MPDFrame*>(&data[0]);        // NOLINT
 	  return thisptr->get_timestamp();
 	}
 

--- a/include/ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp
+++ b/include/ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp
@@ -11,7 +11,7 @@
 #include "iomanager/IOManager.hpp"
 #include "daqdataformats/FragmentHeader.hpp"
 #include "daqdataformats/SourceID.hpp"
-#include "detdataformats/pacman/PACMANFrame.hpp"
+#include "nddetdataformats/PACMANFrame.hpp"
 #include "logging/Logging.hpp"
 #include <cstdint> // uint_t types
 #include <memory>  // unique_ptr

--- a/include/ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp
+++ b/include/ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp
@@ -54,8 +54,8 @@ namespace dunedaq {
 	// comparable based on first timestamp
 	bool operator<(const PACMAN_MESSAGE_STRUCT& other) const
 	{
-	  auto thisptr = reinterpret_cast<const dunedaq::detdataformats::pacman::PACMANFrame*>(&data[0]);        // NOLINT
-	  auto otherptr = reinterpret_cast<const dunedaq::detdataformats::pacman::PACMANFrame*>(&other.data[0]); // NOLINT
+	  auto thisptr = reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&data[0]);        // NOLINT
+	  auto otherptr = reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&other.data[0]); // NOLINT
 	  return (thisptr->get_msg_header((void*)&data[0])->unix_ts) <
 	    (otherptr->get_msg_header((void*)&other.data[0])->unix_ts) // NOLINT
 	    ? true
@@ -66,7 +66,7 @@ namespace dunedaq {
 	uint64_t get_timestamp() const // NOLINT(build/unsigned)
 	{
 	  return ((uint64_t)( // NOLINT
-			     reinterpret_cast<const dunedaq::detdataformats::pacman::PACMANFrame*>(&data[0])
+			     reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&data[0])
 			     ->get_msg_header((void*)&data[0])
 			     ->unix_ts) * // NOLINT
 		  // 1000000000);
@@ -80,12 +80,12 @@ namespace dunedaq {
 	// FIX ME - implement this in the frame later
 	void set_first_timestamp(uint64_t /*ts*/) // NOLINT(build/unsigned)
 	{
-	  // reinterpret_cast<dunedaq::detdataformats::pacman::PACMANFrame*>(&data)->set_timestamp(ts); // NOLINT
+	  // reinterpret_cast<dunedaq::nddetdataformats::PACMANFrame*>(&data)->set_timestamp(ts); // NOLINT
 	}
 
 	uint64_t get_message_type() const // NOLINT(build/unsigned)
 	{
-	  return reinterpret_cast<const dunedaq::detdataformats::pacman::PACMANFrame*>(&data[0]) // NOLINT
+	  return reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&data[0]) // NOLINT
 	    ->get_msg_header((void*)&data[0])                                                    // NOLINT
 	    ->type;
 	}
@@ -96,7 +96,7 @@ namespace dunedaq {
 	  TLOG_DEBUG(1) << "Message Type: " << (char)get_message_type(); // NOLINT
 
 	  uint16_t numWords = // NOLINT
-	    reinterpret_cast<const dunedaq::detdataformats::pacman::PACMANFrame*>(&data[0])
+	    reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&data[0])
 	    ->get_msg_header((void*)&data[0])
 	    ->words; // NOLINT
 
@@ -105,15 +105,15 @@ namespace dunedaq {
 	  for (unsigned int i = 0; i < numWords; i++) {
 	    TLOG_DEBUG(1) << "Inspecting word " << i;
 
-	    dunedaq::detdataformats::pacman::PACMANFrame::PACMANMessageWord* theWord =
-	      reinterpret_cast<const dunedaq::detdataformats::pacman::PACMANFrame*>(&data[0])->get_msg_word((void*)&data[0],
+	    dunedaq::nddetdataformats::PACMANFrame::PACMANMessageWord* theWord =
+	      reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&data[0])->get_msg_word((void*)&data[0],
 													 i); // NOLINT
 
 	    TLOG_DEBUG(1) << "Word type: " << (char)theWord->data_word.type;                // NOLINT
 	    TLOG_DEBUG(1) << "PACMAN I/O Channel: " << (char)theWord->data_word.channel_id; // NOLINT
 	    TLOG_DEBUG(1) << "Word receipt timestamp: " << theWord->data_word.receipt_timestamp;
 
-	    dunedaq::detdataformats::pacman::PACMANFrame::LArPixPacket* thePacket = &(theWord->data_word.larpix_word);
+	    dunedaq::nddetdataformats::PACMANFrame::LArPixPacket* thePacket = &(theWord->data_word.larpix_word);
 
 	    TLOG_DEBUG(1) << "Inspecting packet";
 

--- a/include/ndreadoutlibs/mpd/MPDFrameProcessor.hpp
+++ b/include/ndreadoutlibs/mpd/MPDFrameProcessor.hpp
@@ -11,7 +11,7 @@
 #include "readoutlibs/ReadoutIssues.hpp"
 #include "readoutlibs/models/TaskRawDataProcessorModel.hpp"
 
-#include "detdataformats/mpd/MPDFrame.hpp"
+#include "nddetdataformats/MPDFrame.hpp"
 #include "logging/Logging.hpp"
 #include "ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp"
 #include "readoutlibs/ReadoutLogging.hpp"

--- a/include/ndreadoutlibs/mpd/MPDFrameProcessor.hpp
+++ b/include/ndreadoutlibs/mpd/MPDFrameProcessor.hpp
@@ -31,7 +31,7 @@ class MPDFrameProcessor : public readoutlibs::TaskRawDataProcessorModel<types::M
 public:
   using inherited = readoutlibs::TaskRawDataProcessorModel<types::MPD_MESSAGE_STRUCT>;
   using frameptr = types::MPD_MESSAGE_STRUCT*;
-  using mpdframeptr = dunedaq::detdataformats::mpd::MPDFrame*;
+  using mpdframeptr = dunedaq::nddetdataformats::MPDFrame*;
   using timestamp_t = std::uint64_t; // NOLINT(build/unsigned)
 
   explicit MPDFrameProcessor(std::unique_ptr<readoutlibs::FrameErrorRegistry>& error_registry)

--- a/include/ndreadoutlibs/mpd/MPDListRequestHandler.hpp
+++ b/include/ndreadoutlibs/mpd/MPDListRequestHandler.hpp
@@ -13,7 +13,7 @@
 #include "readoutlibs/models/DefaultRequestHandlerModel.hpp"
 #include "readoutlibs/models/SkipListLatencyBufferModel.hpp"
 
-#include "detdataformats/mpd/MPDFrame.hpp"
+#include "nddetdataformats/MPDFrame.hpp"
 #include "logging/Logging.hpp"
 #include "ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp"
 #include "readoutlibs/ReadoutLogging.hpp"

--- a/include/ndreadoutlibs/pacman/PACMANFrameProcessor.hpp
+++ b/include/ndreadoutlibs/pacman/PACMANFrameProcessor.hpp
@@ -11,7 +11,7 @@
 #include "readoutlibs/ReadoutIssues.hpp"
 #include "readoutlibs/models/TaskRawDataProcessorModel.hpp"
 
-#include "detdataformats/pacman/PACMANFrame.hpp"
+#include "nddetdataformats/PACMANFrame.hpp"
 #include "logging/Logging.hpp"
 #include "ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp"
 #include "readoutlibs/ReadoutLogging.hpp"

--- a/include/ndreadoutlibs/pacman/PACMANFrameProcessor.hpp
+++ b/include/ndreadoutlibs/pacman/PACMANFrameProcessor.hpp
@@ -32,7 +32,7 @@ class PACMANFrameProcessor : public readoutlibs::TaskRawDataProcessorModel<types
 public:
   using inherited = readoutlibs::TaskRawDataProcessorModel<types::PACMAN_MESSAGE_STRUCT>;
   using frameptr = types::PACMAN_MESSAGE_STRUCT*;
-  using pacmanframeptr = dunedaq::detdataformats::pacman::PACMANFrame*;
+  using pacmanframeptr = dunedaq::nddetdataformats::PACMANFrame*;
   using timestamp_t = std::uint64_t; // NOLINT(build/unsigned)
 
   explicit PACMANFrameProcessor(std::unique_ptr<readoutlibs::FrameErrorRegistry>& error_registry)

--- a/include/ndreadoutlibs/pacman/PACMANListRequestHandler.hpp
+++ b/include/ndreadoutlibs/pacman/PACMANListRequestHandler.hpp
@@ -13,7 +13,7 @@
 #include "readoutlibs/models/DefaultRequestHandlerModel.hpp"
 #include "readoutlibs/models/SkipListLatencyBufferModel.hpp"
 
-#include "detdataformats/pacman/PACMANFrame.hpp"
+#include "nddetdataformats/PACMANFrame.hpp"
 #include "logging/Logging.hpp"
 #include "ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp"
 #include "readoutlibs/ReadoutLogging.hpp"


### PR DESCRIPTION
As the first step of the FD/ND release split, `detdataformats` is split into several new packages:
1. `fddetdataformats`
2. `nddetdataformats`
3. `trgdataformats`

The split involves relocation of headers, rename of namespaces, and updates to C
MakeLists.txt and config.cmake.in

This PR contains the necessary changes as a result of the split.

