### PR TITLE
Fixed the MPD_MESSAGE_STRUCT less-than comparator

### DIFF
--- a/include/ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp
+++ b/include/ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp
@@ -37,11 +37,21 @@ namespace dunedaq {
 
 	bool operator<(const MPD_MESSAGE_STRUCT& other) const
 	{
-	  auto thisptr = reinterpret_cast<const dunedaq::nddetdataformats::MPDFrame*>(&data[0]);        // NOLINT
-	  auto otherptr = reinterpret_cast<const dunedaq::nddetdataformats::MPDFrame*>(&other.data[0]); // NOLINT
-	  return (thisptr->get_timestamp() < otherptr->get_timestamp()) // NOLINT
-		      ? true
-		      : false;
+          uint64_t this_timestamp  = 0;  //NOLINT
+          uint64_t other_timestamp = 0;  //NOLINT
+
+          // 27-Apr-2023, KAB: the size of the data member needs to be checked to see whether it
+          // actually contains any data, before trying to interpret the contents.
+          if (data.size() >= sizeof(dunedaq::nddetdataformats::MPDFrame)) {
+            auto thisptr = reinterpret_cast<const dunedaq::nddetdataformats::MPDFrame*>(&data[0]);  // NOLINT
+            this_timestamp = thisptr->get_timestamp();
+          }
+          if (other.data.size() >= sizeof(dunedaq::nddetdataformats::MPDFrame)) {
+            auto otherptr = reinterpret_cast<const dunedaq::nddetdataformats::MPDFrame*>(&other.data[0]);  // NOLINT
+            other_timestamp = otherptr->get_timestamp();
+          }
+
+	  return (this_timestamp < other_timestamp) ? true : false;
 	}
 	
 	uint64_t get_timestamp() const // NOLINT(build/unsigned)


### PR DESCRIPTION
I modified the MPD_MESSAGE_STRUCT less-than comparator to check whether the deque data member has any data in it before trying to use the contents of the deque to fetch a timestamp.

This problem was noticed when running the lbrulibs/integtest/test_mpd-raw.py integration test.  The symptom was that every 4th TriggerRecord or so would have an MPD fragment size of 72 instead of ~3000.  (a fragment size of 72 indicates an empty fragment)

In the readoutlibs code (e.g SkipListLatencyBufferModel), default-constructed instances of data structures are used in various comparison operations with elements in the latency buffer.  A default-constructed instance of the MPD_MESSAGE_STRUCT will have a "deque data" data member of zero size.  However, the size of the deque was not being tested in the "operator<" method and that was leading to random values being used for timestamps and wrong results from "operator<".

To test this fix, I used a software area based on the N23-04-27 nightly build.  And, I had the following repos/branches in my software area:
```
daqconf develop
daq-systemtest develop
dfmodules develop
hsilibs kbiery/MPDtests
lbrulibs kbiery/mpd_integtest_rate_change
ndreadoutlibs kbiery/MPDTypeAdapter_Comparator_Fix
readoutlibs develop
readoutmodules develop
```

This PR is correlated with [PR 51 in lbrulibs](https://github.com/DUNE-DAQ/lbrulibs/pull/51)