### PR TITLE
optimization of ND Type Adapters

### DIFF
--- a/include/ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp
+++ b/include/ndreadoutlibs/NDReadoutMPDTypeAdapter.hpp
@@ -27,12 +27,8 @@ namespace dunedaq {
 	std::vector<char> data ;
 
 	void load_message( const void * load_data, const unsigned int size ) {
-	  char * message = new char [size]; 
-	  std::memcpy(message, load_data, size);
-	  for( unsigned int i = 0 ; i < size ; ++i ) {
-	    data.push_back( *(message+i) ) ;
-	  }
-	  delete[] message;
+	  data.resize(size);
+	  memcpy(&data[0], load_data, size);
 	}
 
 	bool operator<(const NDReadoutMPDTypeAdapter & other) const

--- a/include/ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp
+++ b/include/ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp
@@ -42,13 +42,7 @@ namespace dunedaq {
 	    ers::error(InvalidDataSize(ERS_HERE, size, data.size()));
 	    return;
 	  }
-	  char * message = new char [size]; 
-	 
-	  std::memcpy(message, load_data, size);
-	  for( unsigned int i = 0 ; i < size ; ++i ) {
-	    data[i] = *(message+i) ;
-	  }
-	  delete[] message;
+	  memcpy(&data[0], load_data, size);
 	}
 
 	// comparable based on first timestamp


### PR DESCRIPTION
Optimization of Type adapters implemented. 

**Build Information:**
Software release built from latest.
Using Kurt's hsilibs branch to run mpd integration test. 
git clone https://github.com/DUNE-DAQ/hsilibs.git -b kbiery/MPDtests

**MPD integration test**
`Problem(s) found in logfile /tmp/pytest-of-jtenavid/pytest-49/run0/log_fakehsi_3333.txt:
2023-May-08 11:10:16,052 WARNING [virtual void dunedaq::hsilibs::FakeHSIEventGenerator::do_start(const nlohmann::json&) at /dune/app/users/jtenavid/Software/DuneDAQ/Test/ND_FD_split/sourcecode/hsilibs/plugins/FakeHSIEventGenerator.cpp:128] Special TimeSync handling (conversion to HSIEvent) is active.

FSanity-check passed
Event count is within a tolerance of 10 from an expected value of 100
MPD fragment count of 1 confirmed in all 100 events
All MPD fragments in 100 events have sizes between 448 and 3796
.
`
The outputfile is further inspected with the lbrulibs/tests/mpd-hdf5decoder-RAW.py . All fragments contain valid information.


**PACMAN Integration test**
`Problem(s) found in logfile /tmp/pytest-of-jtenavid/pytest-51/run0/log_rulocalhost0_3336.txt:
2023-May-08 11:27:07,883 WARNING [dunedaq::readoutlibs::DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>::RequestResult dunedaq::readoutlibs::DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>::data_request(dunedaq::dfmessages::DataRequest, bool) [with ReadoutType = dunedaq::ndreadoutlibs::types::NDReadoutPACMANTypeAdapter; LatencyBufferType = dunedaq::readoutlibs::SkipListLatencyBufferModel<dunedaq::ndreadoutlibs::types::NDReadoutPACMANTypeAdapter>; RequestResult = dunedaq::readoutlibs::RequestHandlerConcept<dunedaq::ndreadoutlibs::types::NDReadoutPACMANTypeAdapter, dunedaq::readoutlibs::SkipListLatencyBufferModel<dunedaq::ndreadoutlibs::types::NDReadoutPACMANTypeAdapter> >::RequestResult] at /dune/app/users/jtenavid/Software/DuneDAQ/Test/ND_FD_split/sourcecode/readoutlibs/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx:611] SourceID[subsystem: Detector_Readout id: 0] Trigger Matching result with empty fragment: TS match result on link 0:  Trigger number=1 Oldest stored TS=84178161350000000 Start of window TS=84178161347553875 End of window TS=84178161352553875 Estimated newest stored TS=84178161350000000 Requestor=fragments_to_dataflow0

FSanity-check passed
Event count is within a tolerance of 10 from an expected value of 60
PACMAN fragment count of 1 confirmed in all 61 events
`
This Warning is already present in eflumerf/FixTypeAdapters