### PR TITLE
changing conversion using 62.5MHz clock

### DIFF
--- a/include/ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp
+++ b/include/ndreadoutlibs/NDReadoutPACMANTypeAdapter.hpp
@@ -63,10 +63,9 @@ namespace dunedaq {
 			     reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&data[0])
 			     ->get_msg_header((void*)&data[0])
 			     ->unix_ts) * // NOLINT
-		  // 1000000000);
 		  // FIX ME!!! HARDCODED CONVERSION TO TICKS FROM SECONDS. MULTIPLYING BY 5E7 SINCE
-		  // 50 MHz CLOCK.
-		  50000000);
+		  // 62.5 MHz CLOCK.
+		  62500000);
 	}
 
 	uint64_t get_first_timestamp() const { return get_timestamp(); }
@@ -100,8 +99,7 @@ namespace dunedaq {
 	    TLOG_DEBUG(1) << "Inspecting word " << i;
 
 	    dunedaq::nddetdataformats::PACMANFrame::PACMANMessageWord* theWord =
-	      reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&data[0])->get_msg_word((void*)&data[0],
-													 i); // NOLINT
+	      reinterpret_cast<const dunedaq::nddetdataformats::PACMANFrame*>(&data[0])->get_msg_word((void*)&data[0],i); // NOLINT
 
 	    TLOG_DEBUG(1) << "Word type: " << (char)theWord->data_word.type;                // NOLINT
 	    TLOG_DEBUG(1) << "PACMAN I/O Channel: " << (char)theWord->data_word.channel_id; // NOLINT

--- a/include/ndreadoutlibs/mpd/detail/MPDFrameProcessor.hxx
+++ b/include/ndreadoutlibs/mpd/detail/MPDFrameProcessor.hxx
@@ -55,10 +55,7 @@ MPDFrameProcessor::timestamp_check(frameptr fp)
  * */
 void MPDFrameProcessor::frame_error_check(frameptr /*fp*/)
 {
-  // check error fields
-  // FIX ME - to be implemented
 
-  // fp->inspect_message();
 }
 
 } // namespace ndreadoutlibs

--- a/include/ndreadoutlibs/pacman/PACMANFrameProcessor.hpp
+++ b/include/ndreadoutlibs/pacman/PACMANFrameProcessor.hpp
@@ -62,6 +62,7 @@ protected:
   void frame_error_check(frameptr /*fp*/);
 
 private:
+  uint64_t m_clock_frequency; // NOLINT(build/unsigned)
 };
 
 } // namespace ndreadoutlibs

--- a/include/ndreadoutlibs/pacman/detail/PACMANFrameProcessor.hxx
+++ b/include/ndreadoutlibs/pacman/detail/PACMANFrameProcessor.hxx
@@ -6,6 +6,9 @@ namespace ndreadoutlibs {
 void 
 PACMANFrameProcessor::conf(const nlohmann::json& args)
 {
+  auto config = args["rawdataprocessorconf"].get<readoutlibs::readoutconfig::RawDataProcessorConf>();
+  m_clock_frequency = config.clock_speed_hz;
+
   readoutlibs::TaskRawDataProcessorModel<types::NDReadoutPACMANTypeAdapter>::add_preprocess_task(
     std::bind(&PACMANFrameProcessor::timestamp_check, this, std::placeholders::_1));
   // m_tasklist.push_back( std::bind(&PACMANFrameProcessor::frame_error_check, this, std::placeholders::_1) );
@@ -25,8 +28,7 @@ PACMANFrameProcessor::timestamp_check(frameptr fp)
 
   // Acquire timestamp
   m_current_ts = fp->get_timestamp();
-  TLOG_DEBUG(TLVL_FRAME_RECEIVED) << "Received PACMAN frame timestamp value of " << m_current_ts << " ticks (..." << std::fixed
-                                  << std::setprecision(8) << (static_cast<double>(m_current_ts % (50000000000)) / 50000000.0) << " sec)";
+  TLOG_DEBUG(TLVL_FRAME_RECEIVED) << "Received PACMAN frame timestamp value of " << m_current_ts << " ticks (..." << std::fixed << std::setprecision(8) << (static_cast<double>(m_current_ts % (m_clock_frequency*1000)) / static_cast<double>(m_clock_frequency)) << " sec)"; // NOLINT
 
   // Check timestamp
   // RS warning : not fixed rate!


### PR DESCRIPTION
This pull request contains a simple change in the conversion for the pacman timestamp. Before it was using the 50 MHz frequency to convert to ticks. The new version is using the updated clock frequency of 62.5 MHz